### PR TITLE
updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,25 @@
-FROM codeany/rte-base
+FROM codeany/ib-rte-base
 LABEL key="Infobip"
 
 # Custom Plugins
 USER theia
 COPY plugins/GabrielBB.vscode-lombok-1.0.1.vsix /home/theia/plugins/GabrielBB.vscode-lombok-1.0.1.vsix
 
+# Project Settings
+COPY settings/project-settings.json /home/project/.theia/settings.json
+COPY settings/project-settings.json /home/project/.vscode/settings.json
+
 # Developer tools
 USER root
 
 # Java
 RUN apt-get update && apt-get -y install openjdk-11-jdk maven gradle
+
+# Java :: restart java lang server & exclude files message dialog workaround
+COPY settings/theia-settings.json /root/.theia/settings.json
+
+# Show Initial File
+ENV INIT_FILE_OPEN=/home/project/src/main/java/com/infobip/api/code/examples/SendSms.java
 
 # Code example
 COPY src /home/project/src

--- a/settings/project-settings.json
+++ b/settings/project-settings.json
@@ -1,0 +1,8 @@
+{
+    "files.exclude": {
+        "**/.classpath": true,
+        "**/.project": true,
+        "**/.settings": true,
+        "**/.factorypath": true
+    }
+}

--- a/settings/theia-settings.json
+++ b/settings/theia-settings.json
@@ -1,0 +1,10 @@
+{
+    "java.jdt.ls.vmargs": "-noverify -Xmx1G -XX:+UseG1GC -XX:+UseStringDeduplication -javaagent:\"/tmp/vscode-unpacked/GabrielBB.vscode-lombok-1.0.1.vsix/extension/server/lombok.jar\"",
+    "java.configuration.checkProjectSettingsExclusions": true,
+    "files.exclude": {
+        "**/.classpath": true,
+        "**/.project": true,
+        "**/.settings": true,
+        "**/.factorypath": true
+    }
+}


### PR DESCRIPTION
these update resolves following issues

1. We shouldn't enforce user to restart the environment do to pre-provisioned code editor extension. It's currently happening due to that Lombok annotation processing plugin and I think you're already aware of it.

2. We should navigate the user to the correct file upon the example opening. It currently takes him to the blank editor screen and is kind of awkward experience. Especially when you're using it for the first time.
 
3. Tab title of the example tab in browser is messed up. Not sure if this is due to that plugin issue and environment restart, but it should have Infobip logo and Infobip text as it initially has.